### PR TITLE
feat(screens): add delete button and styling to ManageExpense

### DIFF
--- a/screens/ManageExpense.tsx
+++ b/screens/ManageExpense.tsx
@@ -1,7 +1,9 @@
-import {Text} from "react-native";
+import {StyleSheet, View} from "react-native";
 import {NativeStackScreenProps} from "@react-navigation/native-stack";
 import {RootStackParamList} from "../types";
 import {useLayoutEffect} from "react";
+import IconButton from "../components/common/IconButton";
+import {GlobalStyles} from "../constants/styles";
 type MealsOverviewProps = NativeStackScreenProps<RootStackParamList, 'ManageExpense'>;
 
 function ManageExpense({navigation, route}: MealsOverviewProps) {
@@ -14,7 +16,41 @@ function ManageExpense({navigation, route}: MealsOverviewProps) {
     })
   }, [navigation, isEditing]);
 
-  return <Text>ManageExpenses Screen</Text>
+  function handleDeleteExpense() {
+
+  }
+
+  return (
+    <View style={styles.container}>
+      {
+        isEditing && (
+          <View style={styles.deleteContainer}>
+            <IconButton
+              icon="trash"
+              onPress={handleDeleteExpense}
+              size={36}
+              color={GlobalStyles.colors.error500}
+            />
+          </View>
+        )
+      }
+    </View>
+  )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    backgroundColor: GlobalStyles.colors.primary800
+  },
+  deleteContainer: {
+    marginTop: 16,
+    paddingTop: 8,
+    borderTopWidth: 2,
+    borderTopColor: GlobalStyles.colors.primary200,
+    alignItems: 'center'
+  }
+})
 
 export default ManageExpense


### PR DESCRIPTION
Added a delete button with an `IconButton` and styled the `ManageExpense` screen using `StyleSheet`. Enhanced layout with a container and delete section for better user interaction.