### PR TITLE
refactor(screens): remove console logs in ManageExpense

### DIFF
--- a/screens/ManageExpense.tsx
+++ b/screens/ManageExpense.tsx
@@ -53,14 +53,10 @@ function ManageExpense({navigation, route}: MealsOverviewProps) {
   }
 
   if (loading || submitLoading) {
-    console.log('loading', loading)
-    console.log('submitLoading', submitLoading)
     return <LoadingOverlay />
   }
 
   if (error || submitError) {
-    console.log('error', error)
-    console.log('submitError', submitError)
     return <ErrorOverlay message={error ? error : submitError} onConfirm={() => {
       setError(null)
       setSubmitError(null)


### PR DESCRIPTION
Removed redundant console logs for `loading`, `submitLoading`, `error`, and `submitError` to clean up the `ManageExpense` screen and maintain a production-ready codebase.