### PR TITLE
refactor(reducer): remove redundant id generation in expenses-reducer

### DIFF
--- a/store/expenses/expenses-reducer.ts
+++ b/store/expenses/expenses-reducer.ts
@@ -8,8 +8,7 @@ export default function expensesReducer(state: ExpenseInterface[], action: Actio
       return inverted
     }
     case 'ADDED': {
-      const id = new Date().toString() + Math.random().toString()
-      return [...state, {...action.payload, id}]
+      return [...state, action.payload]
     }
     case 'DELETED': {
       return state.filter((expense) => expense.id !== action.payload)


### PR DESCRIPTION
Simplified the `ADDED` action in `expenses-reducer` by removing unnecessary id generation logic. Relied on `action.payload` to provide complete expense data for improved consistency.